### PR TITLE
add high-level feasibility transform

### DIFF
--- a/lib/src/main/java/org/team100/lib/commands/drivetrain/DriveManually.java
+++ b/lib/src/main/java/org/team100/lib/commands/drivetrain/DriveManually.java
@@ -38,9 +38,12 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
  */
 public class DriveManually extends Command100 {
     private final Supplier<ManualMode.Mode> m_mode;
+    /**
+     * Velocity control in control units, [-1,1] on all axes. This needs to be
+     * mapped to a feasible velocity control as early as possible.
+     */
     private final Supplier<Twist2d> m_twistSupplier;
     private final SwerveDriveSubsystem m_drive;
-
     private final SimpleManualModuleStates m_manualModuleStates;
     private final ManualChassisSpeeds m_manualChassisSpeeds;
     private final ManualFieldRelativeSpeeds m_manualFieldRelativeSpeeds;
@@ -109,10 +112,15 @@ public class DriveManually extends Command100 {
             m_manualWithTargetLock.reset(m_drive.getPose());
         }
 
+        // input in [-1,1] control units
         Twist2d input = m_twistSupplier.get();
         SwerveState state = m_drive.getState();
         Pose2d currentPose = state.pose();
 
+        /**
+         * None of these transformers pay attention to feasibility. Feasibility is
+         * enforced by the drivetrain setpoint generator and desaturator.
+         */
         switch (manualMode) {
             case MODULE_STATE:
                 m_drive.setRawModuleStates(

--- a/lib/src/main/java/org/team100/lib/commands/drivetrain/DriveToWaypoint100.java
+++ b/lib/src/main/java/org/team100/lib/commands/drivetrain/DriveToWaypoint100.java
@@ -15,6 +15,7 @@ import org.team100.lib.trajectory.TrajectoryPlanner;
 import org.team100.lib.trajectory.TrajectoryTimeIterator;
 import org.team100.lib.trajectory.TrajectoryTimeSampler;
 import org.team100.lib.trajectory.TrajectoryVisualization;
+import org.team100.lib.util.DriveUtil;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -108,12 +109,7 @@ public class DriveToWaypoint100 extends Command100 {
         ChassisSpeeds output = m_controller.update(now, currentPose, velocity);
         
         t.log(Level.DEBUG, "/fancy trajectory/chassis speeds", output);
-        if (Double.isNaN(output.vxMetersPerSecond))
-            throw new IllegalStateException("vx is NaN");
-        if (Double.isNaN(output.vyMetersPerSecond))
-            throw new IllegalStateException("vy is NaN");
-        if (Double.isNaN(output.omegaRadiansPerSecond))
-            throw new IllegalStateException("omega is NaN");
+        DriveUtil.checkSpeeds(output);
         m_swerve.setChassisSpeeds(output, dt);
     }
 

--- a/lib/src/main/java/org/team100/lib/commands/drivetrain/Rotate.java
+++ b/lib/src/main/java/org/team100/lib/commands/drivetrain/Rotate.java
@@ -22,9 +22,6 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
  * Rotate in place to the specified angle.
  * 
  * Uses a profile with the holonomic drive controller.
- * 
- * Note there is no allowance for steering delay, so the profile gets way ahead.
- * :(
  */
 public class Rotate extends Command100 {
 
@@ -110,7 +107,8 @@ public class Rotate extends Command100 {
         Twist2d fieldRelativeTarget = m_controller.calculate(currentPose, reference);
 
         if (m_steeringAligned) {
-            // steer normally
+            // steer normally.
+            // there's no feasibility issue because cartesian speed is zero.
             m_robotDrive.driveInFieldCoords(fieldRelativeTarget, dt);
         } else {
             boolean aligned = m_robotDrive.steerAtRest(fieldRelativeTarget, dt);

--- a/lib/src/main/java/org/team100/lib/controller/DriveMotionController.java
+++ b/lib/src/main/java/org/team100/lib/controller/DriveMotionController.java
@@ -14,6 +14,8 @@ public interface DriveMotionController {
     void setTrajectory(TrajectoryTimeIterator trajectory);
 
     /** 
+     * Makes no attempt to enforce feasibility.
+     * 
      * @param timestamp in seconds, use Timer.getFPGATimestamp()
      * @param measurement measured pose
      * @param current_velocity measured speed

--- a/lib/src/main/java/org/team100/lib/controller/DrivePIDFController.java
+++ b/lib/src/main/java/org/team100/lib/controller/DrivePIDFController.java
@@ -35,6 +35,7 @@ public class DrivePIDFController implements DriveMotionController {
         m_prevTimeS = Double.POSITIVE_INFINITY;
     }
 
+    /** Makes no attempt to produce feasible output. */
     @Override
     public ChassisSpeeds update(double timeS, Pose2d measurement, Twist2d current_velocity) {
         if (m_iter == null)

--- a/lib/src/main/java/org/team100/lib/controller/DrivePursuitController.java
+++ b/lib/src/main/java/org/team100/lib/controller/DrivePursuitController.java
@@ -11,6 +11,7 @@ import org.team100.lib.telemetry.Telemetry.Level;
 import org.team100.lib.timing.TimedPose;
 import org.team100.lib.trajectory.TrajectorySamplePoint;
 import org.team100.lib.trajectory.TrajectoryTimeIterator;
+import org.team100.lib.util.DriveUtil;
 import org.team100.lib.util.Math100;
 import org.team100.lib.util.Util;
 
@@ -194,8 +195,7 @@ public class DrivePursuitController implements DriveMotionController {
         chassisSpeeds.omegaRadiansPerSecond = chassisSpeeds.omegaRadiansPerSecond
                 + (kThetakP * mError.getRotation().getRadians());
 
-        if (Double.isNaN(chassisSpeeds.omegaRadiansPerSecond))
-            throw new IllegalStateException("omega is NaN");
+        DriveUtil.checkSpeeds(chassisSpeeds);
 
         return chassisSpeeds;
     }

--- a/lib/src/main/java/org/team100/lib/controller/HolonomicDriveController3.java
+++ b/lib/src/main/java/org/team100/lib/controller/HolonomicDriveController3.java
@@ -58,6 +58,9 @@ public class HolonomicDriveController3 implements HolonomicFieldRelativeControll
                 new Rotation2d(m_thetaController.getPositionError()));
     }
 
+    /**
+     * Makes no attempt to coordinate the axes or provide feasible output.
+     */
     @Override
     public Twist2d calculate(
             Pose2d currentPose,

--- a/lib/src/main/java/org/team100/lib/geometry/GeometryUtil.java
+++ b/lib/src/main/java/org/team100/lib/geometry/GeometryUtil.java
@@ -158,11 +158,7 @@ public class GeometryUtil {
         if (!poseEqual) {
             return false;
         }
-        boolean curvatureEqual = Math.abs(a.curvatureRadPerMeter - b.curvatureRadPerMeter) <= 1e-12;
-        if (!curvatureEqual) {
-            return false;
-        }
-        return true;
+        return Math.abs(a.curvatureRadPerMeter - b.curvatureRadPerMeter) <= 1e-12;
     }
 
     /** direction of the translational part of the twist */

--- a/lib/src/main/java/org/team100/lib/hid/ControlUtil.java
+++ b/lib/src/main/java/org/team100/lib/hid/ControlUtil.java
@@ -1,7 +1,6 @@
 package org.team100.lib.hid;
 
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.geometry.Twist2d;
 
 public class ControlUtil {
     /**
@@ -21,13 +20,6 @@ public class ControlUtil {
 
     public static double clamp(double input, double clamp) {
         return MathUtil.clamp(input, -clamp, clamp);
-    }
-
-    public static Twist2d clampTwist(Twist2d input, double maxMagnitude) {
-        double hyp = Math.hypot(input.dx, input.dy);
-        double clamped = Math.min(hyp, maxMagnitude);
-        double ratio = clamped / hyp;
-        return new Twist2d(ratio * input.dx, ratio * input.dy, input.dtheta);
     }
 
     private ControlUtil() {

--- a/lib/src/main/java/org/team100/lib/hid/DriverControl.java
+++ b/lib/src/main/java/org/team100/lib/hid/DriverControl.java
@@ -10,6 +10,10 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
  * controlling the drivetrain only.
  * 
  * Implementations should do their own deadbanding, scaling, expo, etc.
+ * 
+ * The intention is for this interface to represent the control, not to
+ * represent the control's effect on the robot. So, for example, velocity inputs
+ * are scaled to control units, ([-1,1]), not robot units (m/s).
  */
 public interface DriverControl {
     public enum Speed {
@@ -23,9 +27,23 @@ public interface DriverControl {
     }
 
     /**
-     * forward positive, left positive, counterclockwise positive
+     * Proportional robot velocity control.
      * 
-     * @return [-1,1]
+     * Forward positive, left positive, counterclockwise positive, [-1,1]
+     *
+     * The expectation is that the control interval, [-1,1] will be transformed to
+     * robot motion in some simple way.
+     * 
+     * There are two aspects of this transformation that are not simple:
+     * 
+     * 1. Controls should expect translational input outside the unit circle to be
+     * clipped. If you'd like to avoid that, then squash the input in the control
+     * class.
+     * 
+     * 2. Translation and rotation conflict: in reality, full translation speed
+     * implies zero rotation speed, and vice versa. The SwerveSetpointGenerator and
+     * the SwerveDriveKinemataics desaturator address this issue, though at a lower
+     * level.
      */
     default Twist2d twist() {
         return new Twist2d();
@@ -92,13 +110,13 @@ public interface DriverControl {
     }
 
     default Trigger actualCircle() {
-        return new Trigger(()->false);
+        return new Trigger(() -> false);
     }
 
     // this exists to bind to commands we don't want to run,
     // but we don't want them to rot either.
     default Trigger never() {
-        return new Trigger(()->false);
+        return new Trigger(() -> false);
     }
 
     default boolean annunicatorTest() {

--- a/lib/src/main/java/org/team100/lib/hid/DriverXboxControl.java
+++ b/lib/src/main/java/org/team100/lib/hid/DriverXboxControl.java
@@ -43,10 +43,19 @@ public class DriverXboxControl implements DriverControl {
         return new JoystickButton(m_controller.getHID(), 8);
     }
 
+    /**
+     * Applies expo to the magnitude of the cartesian input, since these are "round"
+     * joysticks.
+     */
     @Override
     public Twist2d twist() {
-        double dx = expo(deadband(-1.0 * clamp(m_controller.getRightY(), 1), kDeadband, 1), kExpo);
-        double dy = expo(deadband(-1.0 * clamp(m_controller.getRightX(), 1), kDeadband, 1), kExpo);
+        double x = deadband(-1.0 * clamp(m_controller.getRightY(), 1), kDeadband, 1);
+        double y = deadband(-1.0 * clamp(m_controller.getRightX(), 1), kDeadband, 1);
+        double r = Math.hypot(x, y);
+        double expoR = expo(r, kExpo);
+        double ratio = expoR / r;
+        double dx = ratio * x;
+        double dy = ratio * y;
         double dtheta = expo(deadband(-1.0 * clamp(m_controller.getLeftX(), 1), kDeadband, 1), kExpo);
         t.log(Level.DEBUG, "/Xbox/right y", m_controller.getRightY());
         t.log(Level.DEBUG, "/Xbox/right x", m_controller.getRightX());

--- a/lib/src/main/java/org/team100/lib/hid/JoystickControl.java
+++ b/lib/src/main/java/org/team100/lib/hid/JoystickControl.java
@@ -66,6 +66,10 @@ public abstract class JoystickControl implements DriverControl {
         // return button(4);
     }
 
+    /**
+     * Applies expo to each axis individually, works for "square" joysticks.
+     * The square response of this joystick should be clamped by the consumer.
+     */
     @Override
     public Twist2d twist() {
         double dx = expo(deadband(-1.0 * clamp(m_controller.getY(), 1), kDeadband, 1), kExpo);

--- a/lib/src/main/java/org/team100/lib/hid/Pilot.java
+++ b/lib/src/main/java/org/team100/lib/hid/Pilot.java
@@ -46,6 +46,10 @@ public class Pilot implements DriverControl {
         return button(3);
     }
 
+    /**
+     * Applies expo to each axis individually, works for "square" joysticks.
+     * The square response of this joystick should be clamped by the consumer.
+     */
     @Override
     public Twist2d twist() {
         double dx = expo(deadband(-1.0 * clamp(axis(1), 1), kDeadband, 1), kExpo);

--- a/lib/src/main/java/org/team100/lib/hid/RealFlight.java
+++ b/lib/src/main/java/org/team100/lib/hid/RealFlight.java
@@ -1,7 +1,6 @@
 package org.team100.lib.hid;
 
 import static org.team100.lib.hid.ControlUtil.clamp;
-import static org.team100.lib.hid.ControlUtil.clampTwist;
 import static org.team100.lib.hid.ControlUtil.deadband;
 import static org.team100.lib.hid.ControlUtil.expo;
 
@@ -52,11 +51,16 @@ public class RealFlight implements DriverControl {
         return hid.getHID().getName();
     }
 
+    /**
+     * Applies expo to each axis individually, works for "square" joysticks.
+     * The square response of this joystick should be clamped by the consumer.
+     */
+    @Override
     public Twist2d twist() {
         double dx = expo(deadband(-1.0 * clamp(scaled(0), 1), kDeadband, 1), kExpo);
         double dy = expo(deadband(-1.0 * clamp(scaled(1), 1), kDeadband, 1), kExpo);
         double dtheta = expo(deadband(-1.0 * clamp(scaled(4), 1), kDeadband, 1), kExpo);
-        return clampTwist(new Twist2d(dx, dy, dtheta), 1.0);
+        return new Twist2d(dx, dy, dtheta);
     }
 
     @Override

--- a/lib/src/main/java/org/team100/lib/motion/drivetrain/SwerveDriveSubsystem.java
+++ b/lib/src/main/java/org/team100/lib/motion/drivetrain/SwerveDriveSubsystem.java
@@ -129,6 +129,8 @@ public class SwerveDriveSubsystem extends SubsystemBase {
     /**
      * Scales the supplied twist by the "speed" driver control modifier.
      * 
+     * Feasibility is enforced by the setpoint generator (if enabled) and the desaturator.
+     * 
      * @param twist  Field coordinate velocities in meters and radians per second.
      * @param kDtSec time in the future for the setpoint generator to calculate
      */
@@ -170,6 +172,9 @@ public class SwerveDriveSubsystem extends SubsystemBase {
         return m_swerveLocal.steerAtRest(targetChassisSpeeds, kDtSec);
     }
 
+    /**
+     * Feasibility is enforced by the setpoint generator (if enabled) and the desaturator.
+     */
     public void setChassisSpeeds(ChassisSpeeds speeds, double kDtSec) {
         m_swerveLocal.setChassisSpeeds(speeds, kDtSec);
     }

--- a/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualChassisSpeeds.java
+++ b/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualChassisSpeeds.java
@@ -22,13 +22,29 @@ public class ManualChassisSpeeds {
         m_swerveKinodynamics = swerveKinodynamics;
     }
 
+    /**
+     * Clips the input to the unit circle, scales to maximum (not simultaneously
+     * feasible) speeds, and then desaturates to a feasible holonomic velocity.
+     *
+     * @param input in control units, [-1,1]
+     * @return feasible chassis speeds in m/s and rad/s
+     */
     public ChassisSpeeds apply(Twist2d input) {
-        ChassisSpeeds speeds = DriveUtil.scaleChassisSpeeds(
-                input,
+        // clip the input to the unit circle
+        Twist2d clipped = DriveUtil.clampTwist(input, 1.0);
+        // scale to max in both translation and rotation
+
+        ChassisSpeeds scaled = DriveUtil.scaleChassisSpeeds(
+                clipped,
                 m_swerveKinodynamics.getMaxDriveVelocityM_S(),
                 m_swerveKinodynamics.getMaxAngleSpeedRad_S());
+
+        // desaturate to feasibility
+        ChassisSpeeds speeds = m_swerveKinodynamics.analyticDesaturation(scaled);
+
         t.log(Level.DEBUG, "/manual robot relative/vx m_s", speeds.vxMetersPerSecond);
         t.log(Level.DEBUG, "/manual robot relative/vy m_s", speeds.vyMetersPerSecond);
+        t.log(Level.DEBUG, "/manual robot relative/omega rad_s", speeds.omegaRadiansPerSecond);
         return speeds;
     }
 }

--- a/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualFieldRelativeSpeeds.java
+++ b/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualFieldRelativeSpeeds.java
@@ -20,11 +20,26 @@ public class ManualFieldRelativeSpeeds {
         m_swerveKinodynamics = swerveKinodynamics;
     }
 
+    /**
+     * Clips the input to the unit circle, scales to maximum (not simultaneously
+     * feasible) speeds, and then desaturates to a feasible holonomic velocity.
+     * 
+     * @param twist in control units, [-1,1]
+     * @return feasible field-relative velocity in m/s and rad/s
+     */
     public Twist2d apply(Twist2d input) {
+        // clip the input to the unit circle
+        Twist2d clipped = DriveUtil.clampTwist(input, 1.0);
+
+        // scale to max in both translation and rotation
         Twist2d twistM_S = DriveUtil.scale(
-                input,
+                clipped,
                 m_swerveKinodynamics.getMaxDriveVelocityM_S(),
                 m_swerveKinodynamics.getMaxAngleSpeedRad_S());
+
+        // desaturate to feasibility
+        twistM_S = m_swerveKinodynamics.analyticDesaturation(twistM_S);
+
         t.log(Level.DEBUG, "/manual field relative/twist x m_s", twistM_S.dx);
         t.log(Level.DEBUG, "/manual field relative/twist y m_s", twistM_S.dy);
         t.log(Level.DEBUG, "/manual field relative/twist theta rad_s", twistM_S.dtheta);

--- a/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualWithHeading.java
+++ b/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/ManualWithHeading.java
@@ -27,8 +27,12 @@ import edu.wpi.first.math.geometry.Twist2d;
  */
 public class ManualWithHeading {
     private static final double kDtSec = 0.02;
+    /**
+     * Relative rotational speed. Use a moderate value to trade rotation for
+     * translation
+     */
+    private static final double kRotationSpeed = 0.5;
     private final Telemetry t = Telemetry.get();
-
     private final SwerveKinodynamics m_swerveKinodynamics;
     private final HeadingInterface m_heading;
     private final Supplier<Rotation2d> m_desiredRotation;
@@ -36,9 +40,9 @@ public class ManualWithHeading {
     private final PIDController m_thetaController;
     private final PIDController m_omegaController;
 
-    public Rotation2d m_goal = null;
     public final TrapezoidProfile100 m_profile;
-    State100 m_setpoint;
+    Rotation2d m_goal = null;
+    State100 m_thetaSetpoint;
 
     public ManualWithHeading(
             SwerveKinodynamics swerveKinodynamics,
@@ -53,36 +57,57 @@ public class ManualWithHeading {
         m_omegaController = omegaController;
         m_latch = new HeadingLatch();
         Constraints c = new Constraints(
-                swerveKinodynamics.getMaxAngleSpeedRad_S(),
-                swerveKinodynamics.getMaxAngleAccelRad_S2());
+                swerveKinodynamics.getMaxAngleSpeedRad_S() * kRotationSpeed,
+                swerveKinodynamics.getMaxAngleAccelRad_S2() * kRotationSpeed);
         m_profile = new TrapezoidProfile100(c, 0.01);
     }
 
     public void reset(Pose2d currentPose) {
         m_goal = null;
         m_latch.unlatch();
-        m_setpoint = new State100(currentPose.getRotation().getRadians(), m_heading.getHeadingRateNWU());
+        m_thetaSetpoint = new State100(currentPose.getRotation().getRadians(), m_heading.getHeadingRateNWU());
         m_thetaController.reset();
         m_omegaController.reset();
     }
 
     /**
-     * control for fixed dt = 0.02.
+     * Clips the input to the unit circle, scales to maximum (not simultaneously
+     * feasible) speeds, and then desaturates to a feasible holonomic velocity.
+     * 
+     * If you touch the POV and not the twist rotation, it remembers the POV. if you
+     * use the twist rotation, it forgets and just uses that.
+     * 
+     * Desaturation prefers the rotational profile completely in the snap case, and
+     * normally in the non-snap case.
+     * 
+     * This uses a fixed dt = 0.02 for the profile.
+     * 
+     * @param currentPose from the pose estimator
+     * @param twist1_1    control units, [-1,1]
+     * @return feasible field-relative velocity in m/s and rad/s
      */
     public Twist2d apply(Pose2d currentPose, Twist2d twist1_1) {
+        // clip the input to the unit circle
+        Twist2d clipped = DriveUtil.clampTwist(twist1_1, 1.0);
+
         Rotation2d currentRotation = currentPose.getRotation();
         double headingMeasurement = currentRotation.getRadians();
         double headingRate = m_heading.getHeadingRateNWU();
 
         Rotation2d pov = m_desiredRotation.get();
-        m_goal = m_latch.latchedRotation(pov, twist1_1);
+        m_goal = m_latch.latchedRotation(pov, clipped);
         if (m_goal == null) {
             // we're not in snap mode, so it's pure manual
             t.log(Level.DEBUG, "/ManualWithHeading/mode", "free");
-            return DriveUtil.scale(
-                    twist1_1,
+
+            // scale to max in both translation and rotation
+            Twist2d twistM_S = DriveUtil.scale(
+                    clipped,
                     m_swerveKinodynamics.getMaxDriveVelocityM_S(),
                     m_swerveKinodynamics.getMaxAngleSpeedRad_S());
+
+            // desaturate to feasibility
+            return m_swerveKinodynamics.analyticDesaturation(twistM_S);
         }
 
         // take the short path
@@ -90,26 +115,26 @@ public class ManualWithHeading {
                 Math100.getMinDistance(headingMeasurement, m_goal.getRadians()));
 
         // use the modulus cloest to the measurement
-        m_setpoint = new State100(
-                Math100.getMinDistance(headingMeasurement, m_setpoint.x()),
-                m_setpoint.v());
+        m_thetaSetpoint = new State100(
+                Math100.getMinDistance(headingMeasurement, m_thetaSetpoint.x()),
+                m_thetaSetpoint.v());
 
         // in snap mode we take dx and dy from the user, and use the profile for dtheta.
         // the omega goal in snap mode is always zero.
         State100 goalState = new State100(m_goal.getRadians(), 0);
-        m_setpoint = m_profile.calculate(kDtSec, m_setpoint, goalState);
+        m_thetaSetpoint = m_profile.calculate(kDtSec, m_thetaSetpoint, goalState);
 
         // this is user input
         Twist2d twistM_S = DriveUtil.scale(
-                twist1_1,
+                clipped,
                 m_swerveKinodynamics.getMaxDriveVelocityM_S(),
                 m_swerveKinodynamics.getMaxAngleSpeedRad_S());
         // the snap overrides the user input for omega.
-        double thetaFF = m_setpoint.v();
+        double thetaFF = m_thetaSetpoint.v();
 
-        double thetaFB = m_thetaController.calculate(headingMeasurement, m_setpoint.x());
+        double thetaFB = m_thetaController.calculate(headingMeasurement, m_thetaSetpoint.x());
 
-        double omegaFB = m_omegaController.calculate(headingRate, m_setpoint.v());
+        double omegaFB = m_omegaController.calculate(headingRate, m_thetaSetpoint.v());
 
         double omega = MathUtil.clamp(
                 thetaFF + thetaFB + omegaFB,
@@ -118,13 +143,16 @@ public class ManualWithHeading {
         Twist2d twistWithSnapM_S = new Twist2d(twistM_S.dx, twistM_S.dy, omega);
 
         t.log(Level.DEBUG, "/ManualWithHeading/mode", "snap");
-        t.log(Level.DEBUG, "/ManualWithHeading/reference/theta", m_setpoint.x());
-        t.log(Level.DEBUG, "/ManualWithHeading/reference/omega", m_setpoint.v());
+        t.log(Level.DEBUG, "/ManualWithHeading/reference/theta", m_thetaSetpoint.x());
+        t.log(Level.DEBUG, "/ManualWithHeading/reference/omega", m_thetaSetpoint.v());
         t.log(Level.DEBUG, "/ManualWithHeading/measurement/theta", headingMeasurement);
         t.log(Level.DEBUG, "/ManualWithHeading/measurement/omega", headingRate);
-        t.log(Level.DEBUG, "/ManualWithHeading/error/theta", m_setpoint.x() - headingMeasurement);
-        t.log(Level.DEBUG, "/ManualWithHeading/error/omega", m_setpoint.v() - headingRate);
+        t.log(Level.DEBUG, "/ManualWithHeading/error/theta", m_thetaSetpoint.x() - headingMeasurement);
+        t.log(Level.DEBUG, "/ManualWithHeading/error/omega", m_thetaSetpoint.v() - headingRate);
 
+        // desaturate the end result to feasibility by preferring the rotation over
+        // translation
+        twistWithSnapM_S = m_swerveKinodynamics.preferRotation(twistWithSnapM_S);
         return twistWithSnapM_S;
     }
 }

--- a/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/SimpleManualModuleStates.java
+++ b/lib/src/main/java/org/team100/lib/motion/drivetrain/manual/SimpleManualModuleStates.java
@@ -24,6 +24,11 @@ public class SimpleManualModuleStates {
         m_swerveKinodynamics = swerveKinodynamics;
     }
 
+    /**
+     * There's no conflict between translation and rotation velocities in this mode.
+     * 
+     * @param input in control units [-1,1]
+     */
     public SwerveModuleState[] apply(Twist2d input) {
         // dtheta is from [-1, 1], so angle is [-pi, pi]
         Rotation2d angle = Rotation2d.fromRadians(Math.PI * input.dtheta);

--- a/lib/src/main/java/org/team100/lib/util/DriveUtil.java
+++ b/lib/src/main/java/org/team100/lib/util/DriveUtil.java
@@ -3,9 +3,12 @@ package org.team100.lib.util;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.RobotBase;
 
 public class DriveUtil {
     /**
+     * This makes no attempt to address infeasibilty, it just multiplies.
+     * 
      * @param twist    [-1,1]
      * @param maxSpeed meters per second
      * @param maxRot   radians per second
@@ -18,12 +21,66 @@ public class DriveUtil {
                 maxRot * MathUtil.clamp(twist.dtheta, -1, 1));
     }
 
+    /**
+     * This makes no attempt to address infeasibilty, it just multiplies.
+     * 
+     * @param twist    [-1,1]
+     * @param maxSpeed meters per second
+     * @param maxRot   radians per second
+     * @return meters and rad per second as specified by speed limits
+     */
     public static ChassisSpeeds scaleChassisSpeeds(Twist2d twist, double maxSpeed, double maxRot) {
         Twist2d scaled = scale(twist, maxSpeed, maxRot);
         return new ChassisSpeeds(
                 scaled.dx,
                 scaled.dy,
                 scaled.dtheta);
+    }
+
+    /**
+     * Clamp the translational velocity to the unit circle by clipping outside.
+     * 
+     * This means that there will be no stick response outside the circle, but the
+     * inside will be unchanged.
+     * 
+     * The argument for clipping is that it leaves the response inside the circle
+     * alone: with squashing, the diagonals are more sensitive.
+     * 
+     * The argument for squashing is that it preserves relative response in
+     * the corners: with clipping, going full speed diagonally and then "slowing
+     * down a little" will do nothing.
+     * 
+     * If you'd like to avoid clipping, then squash the input upstream, in the
+     * control class.
+     */
+    public static Twist2d clampTwist(Twist2d input, double maxMagnitude) {
+        double hyp = Math.hypot(input.dx, input.dy);
+        if (hyp < 1e-12) return input;
+        double clamped = Math.min(hyp, maxMagnitude);
+        double ratio = clamped / hyp;
+        return new Twist2d(ratio * input.dx, ratio * input.dy, input.dtheta);
+    }
+
+    /** crash the robot in simulation or just substitute zero in prod */
+    public static void checkSpeeds(ChassisSpeeds speeds) {
+        try {
+            if (Double.isNaN(speeds.vxMetersPerSecond))
+                throw new IllegalStateException("vx is NaN");
+            if (Double.isNaN(speeds.vyMetersPerSecond))
+                throw new IllegalStateException("vy is NaN");
+            if (Double.isNaN(speeds.omegaRadiansPerSecond))
+                throw new IllegalStateException("omega is NaN");
+        } catch (IllegalStateException e) {
+            if (RobotBase.isReal()) {
+                Util.warn("NaN speeds!");
+                speeds.vxMetersPerSecond = 0;
+                speeds.vyMetersPerSecond = 0;
+                speeds.omegaRadiansPerSecond = 0;
+                return;
+            }
+            // in test/sim, it's ok to throw
+            throw e;
+        }
     }
 
     private DriveUtil() {

--- a/lib/src/test/java/org/team100/lib/hid/ControlUtilTest.java
+++ b/lib/src/test/java/org/team100/lib/hid/ControlUtilTest.java
@@ -4,9 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import edu.wpi.first.math.geometry.Twist2d;
-
-public class ControlUtilTest {
+class ControlUtilTest {
     private static final double kDelta = 0.001;
 
     @Test
@@ -24,21 +22,4 @@ public class ControlUtilTest {
     void testClamp() {
         assertEquals(0.5, ControlUtil.clamp(2, 0.5), kDelta);
     }
-
-    @Test
-    void testClampTwist() {
-        {
-            Twist2d input = new Twist2d(1, 1, 0);
-            Twist2d actual = ControlUtil.clampTwist(input, 1);
-            assertEquals(0.707, actual.dx, kDelta);
-            assertEquals(0.707, actual.dy, kDelta);
-        }
-       {
-            Twist2d input = new Twist2d(0.5, 0.5, 0);
-            Twist2d actual = ControlUtil.clampTwist(input, 1);
-            assertEquals(0.5, actual.dx, kDelta);
-            assertEquals(0.5, actual.dy, kDelta);
-        }
-    }
-
 }

--- a/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualChassisSpeedsTest.java
+++ b/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualChassisSpeedsTest.java
@@ -26,11 +26,15 @@ class ManualChassisSpeedsTest {
     @Test
     void testChassisSpeedsNonzero() {
         SwerveKinodynamics limits = SwerveKinodynamicsFactory.forTest();
+        assertEquals(1, limits.getMaxDriveVelocityM_S(), kDelta);
+        assertEquals(2.828, limits.getMaxAngleSpeedRad_S(), kDelta);
         ManualChassisSpeeds manual = new ManualChassisSpeeds(limits);
+        // clipping to the unit circle, then desaturating.
         Twist2d input = new Twist2d(1, 2, 3);
         ChassisSpeeds speeds = manual.apply(input);
-        assertEquals(1, speeds.vxMetersPerSecond, kDelta);
-        assertEquals(1, speeds.vyMetersPerSecond, kDelta); // speed limit
-        assertEquals(2.828, speeds.omegaRadiansPerSecond, kDelta); // speed limit
+
+        assertEquals(0.223, speeds.vxMetersPerSecond, kDelta);
+        assertEquals(0.447, speeds.vyMetersPerSecond, kDelta);
+        assertEquals(1.414, speeds.omegaRadiansPerSecond, kDelta);
     }
 }

--- a/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualFieldRelativeSpeedsTest.java
+++ b/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualFieldRelativeSpeedsTest.java
@@ -26,11 +26,12 @@ class ManualFieldRelativeSpeedsTest {
     void testTwistNonzero() {
         SwerveKinodynamics limits = SwerveKinodynamicsFactory.forTest();
         ManualFieldRelativeSpeeds manual = new ManualFieldRelativeSpeeds(limits);
+        // these inputs are clipped and desaturated
         Twist2d input = new Twist2d(1, 2, 3);
         Twist2d twist = manual.apply(input);
-        assertEquals(1, twist.dx, kDelta);
-        assertEquals(1, twist.dy, kDelta); // speed limit
-        assertEquals(2.828, twist.dtheta, kDelta); // speed limit
+        assertEquals(0.223, twist.dx, kDelta);
+        assertEquals(0.447, twist.dy, kDelta);
+        assertEquals(1.414, twist.dtheta, kDelta);
     }
 
 }

--- a/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualWithHeadingTest.java
+++ b/lib/src/test/java/org/team100/lib/motion/drivetrain/manual/ManualWithHeadingTest.java
@@ -118,8 +118,8 @@ class ManualWithHeadingTest {
         Pose2d currentPose = GeometryUtil.kPoseZero;
         m_manualWithHeading.reset(currentPose);
         // reset means setpoint is currentpose.
-        assertEquals(0, m_manualWithHeading.m_setpoint.x(), kDelta);
-        assertEquals(0, m_manualWithHeading.m_setpoint.v(), kDelta);
+        assertEquals(0, m_manualWithHeading.m_thetaSetpoint.x(), kDelta);
+        assertEquals(0, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
 
         // face towards +y
         desiredRotation = GeometryUtil.kRotation90;
@@ -136,11 +136,11 @@ class ManualWithHeadingTest {
         // confirm the goal is what desiredRotation says.
         assertEquals(Math.PI / 2, m_manualWithHeading.m_goal.getRadians(), kDelta);
         // we did one calculation so setpoint is not zero
-        assertEquals(0.0002, m_manualWithHeading.m_setpoint.x(), kDelta);
-        assertEquals(0.169, m_manualWithHeading.m_setpoint.v(), kDelta);
+        assertEquals(0.0002, m_manualWithHeading.m_thetaSetpoint.x(), kDelta);
+        assertEquals(0.084, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
 
         // and output is not zero
-        verify(0, 0, 0.769, twistM_S);
+        verify(0, 0, 0.384, twistM_S);
 
         // let go of the pov to let the profile run.
         desiredRotation = null;
@@ -148,9 +148,9 @@ class ManualWithHeadingTest {
         // say we've rotated a little.
         currentPose = new Pose2d(0, 0, new Rotation2d(0.5));
         // cheat the setpoint for the test
-        m_manualWithHeading.m_setpoint = new State100(0.5, 1);
+        m_manualWithHeading.m_thetaSetpoint = new State100(0.5, 1);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
-        assertEquals(1.169, m_manualWithHeading.m_setpoint.v(), kDelta);
+        assertEquals(1.085, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
         assertNotNull(m_manualWithHeading.m_goal);
 
         // still pushing since the profile isn't done
@@ -159,17 +159,17 @@ class ManualWithHeadingTest {
         // mostly rotated
         currentPose = new Pose2d(0, 0, new Rotation2d(1.55));
         // cheat the setpoint for the test
-        m_manualWithHeading.m_setpoint = new State100(1.55, 0.2);
+        m_manualWithHeading.m_thetaSetpoint = new State100(1.55, 0.2);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
-        assertEquals(0.369, m_manualWithHeading.m_setpoint.v(), kDelta);
+        assertEquals(0.284, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
         assertNotNull(m_manualWithHeading.m_goal);
 
         // almost done
-        verify(0, 0, 1.683, twistM_S);
+        verify(0, 0, 1.299, twistM_S);
 
         // done
         currentPose = new Pose2d(0, 0, new Rotation2d(Math.PI / 2));
-        m_manualWithHeading.m_setpoint = new State100(Math.PI / 2, 0);
+        m_manualWithHeading.m_thetaSetpoint = new State100(Math.PI / 2, 0);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
         assertNotNull(m_manualWithHeading.m_goal);
 
@@ -212,14 +212,16 @@ class ManualWithHeadingTest {
         State100 initial = new State100(0, 0);
         State100 goal = new State100(Math.PI / 2, 0);
         assertEquals(0, m_manualWithHeading.m_profile.calculate(0, initial, goal).v(), kDelta);
-        verify(0, 0, 0.769, twistM_S);
+        // theta gets half of max
+        verify(0, 0, 0.384, twistM_S);
 
         // say we've rotated a little.
         currentPose = new Pose2d(0, 0, new Rotation2d(0.5));
         // cheat the setpoint for the test
-        m_manualWithHeading.m_setpoint = new State100(0.5, 1);
+        m_manualWithHeading.m_thetaSetpoint = new State100(0.5, 1);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
-        assertEquals(1.169, m_manualWithHeading.m_setpoint.v(), kDelta);
+        // profile gets half v
+        assertEquals(1.085, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
         assertNotNull(m_manualWithHeading.m_goal);
 
         // still pushing since the profile isn't done
@@ -228,17 +230,18 @@ class ManualWithHeadingTest {
         // mostly rotated, so the FB controller is calm
         currentPose = new Pose2d(0, 0, new Rotation2d(1.555));
         // cheat the setpoint for the test
-        m_manualWithHeading.m_setpoint = new State100(1.555, 0.2);
+        m_manualWithHeading.m_thetaSetpoint = new State100(1.555, 0.2);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
-        assertEquals(0.369, m_manualWithHeading.m_setpoint.v(), kDelta);
+        // profile gets half v
+        assertEquals(0.285, m_manualWithHeading.m_thetaSetpoint.v(), kDelta);
         assertNotNull(m_manualWithHeading.m_goal);
 
         // almost done
-        verify(0, 0, 1.683, twistM_S);
+        verify(0, 0, 1.299, twistM_S);
 
         // at the setpoint
         currentPose = new Pose2d(0, 0, new Rotation2d(Math.PI / 2));
-        m_manualWithHeading.m_setpoint = new State100(Math.PI / 2, 0);
+        m_manualWithHeading.m_thetaSetpoint = new State100(Math.PI / 2, 0);
         twistM_S = m_manualWithHeading.apply(currentPose, twist1_1);
         assertNotNull(m_manualWithHeading.m_goal);
         // there should be no more profile to follow

--- a/lib/src/test/java/org/team100/lib/timing/SwerveDriveDynamicsConstraintTest.java
+++ b/lib/src/test/java/org/team100/lib/timing/SwerveDriveDynamicsConstraintTest.java
@@ -105,4 +105,6 @@ class SwerveDriveDynamicsConstraintTest {
         assertEquals(5, implied.omegaRadiansPerSecond, kDelta);
     }
 
+  
+
 }

--- a/lib/src/test/java/org/team100/lib/util/DriveUtilTest.java
+++ b/lib/src/test/java/org/team100/lib/util/DriveUtilTest.java
@@ -1,0 +1,38 @@
+package org.team100.lib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.math.geometry.Twist2d;
+
+class DriveUtilTest {
+    private static final double kDelta = 0.001;
+
+    @Test
+    void testClampTwist() {
+        {
+            // zero is no-op
+            Twist2d input = new Twist2d(0, 0, 0);
+            Twist2d actual = DriveUtil.clampTwist(input, 1);
+            assertEquals(0, actual.dx, kDelta);
+            assertEquals(0, actual.dy, kDelta);
+            assertEquals(0, actual.dtheta, kDelta);
+        }
+        {
+            // clip to the unit circle.
+            Twist2d input = new Twist2d(1, 1, 0);
+            Twist2d actual = DriveUtil.clampTwist(input, 1);
+            assertEquals(0.707, actual.dx, kDelta);
+            assertEquals(0.707, actual.dy, kDelta);
+        }
+        {
+            // leave the inside alone
+            Twist2d input = new Twist2d(0.5, 0.5, 0);
+            Twist2d actual = DriveUtil.clampTwist(input, 1);
+            assertEquals(0.5, actual.dx, kDelta);
+            assertEquals(0.5, actual.dy, kDelta);
+        }
+    }
+
+}


### PR DESCRIPTION
the idea is to give the swerve setpoint generator less to do by solving more of the problem at a higher level in the stack.  one important difference is that now the rotational profile in snaps gets preference, so it should be "snappier."